### PR TITLE
Fix the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: haskell
 install:
   - cabal update
-  - cabal install bytestring cereal conduit transformers crypto-api cryptocipher cryptohash skein hspec
+  - cabal install --dependencies-only --enable-tests


### PR DESCRIPTION
Make sure all dependencies are installed. The recent travis failures
were due to missing dependencies. All the build flags mean that manually
managing dependencies got quite hard.